### PR TITLE
Fix borders not being constant height

### DIFF
--- a/sigma9.css
+++ b/sigma9.css
@@ -82,6 +82,11 @@ a.newpage {
 	width: 95%;
 }
 
+hr {
+	height: 0;
+	border-top: thin solid #aaa;
+}
+
 /* GLOBAL WIDTH */
 #header, #top-bar {
 	width: 90%;


### PR DESCRIPTION
On some browsers `hr` are [not constant height](https://stackoverflow.com/questions/56076634/hr-tags-render-with-different-height):

![hrbad](https://user-images.githubusercontent.com/29130152/98803253-5f2e2800-240c-11eb-9a28-6863418d43c7.png)
This can be fixed by using a `border-width` of `thin`, which is [drawn at constant width regardless of zoom level](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width#Values):

![hrgood](https://user-images.githubusercontent.com/29130152/98803695-1034c280-240d-11eb-8c77-d4717d24e638.png)
However, Wikidot `hr` are currently drawn with `height: 1px` and `background-color`, not `height: 0` and `border-top`. This change may affect CSS themes that style `hr`. Some investigation and manual fixes may be needed.