### PR TITLE
sidebar link color

### DIFF
--- a/sigma.css
+++ b/sigma.css
@@ -136,11 +136,6 @@ a:hover {
 	background-color: transparent;
 }
 
-#side-bar a:visited,
-#interwiki a:visited {
-	color: #b01;
-}
-
 a.newpage {
 	color: #d61;
 	text-decoration: none;
@@ -509,6 +504,11 @@ sup {
 	margin-right: 2px;
 	position: relative;
 	bottom: -2px;
+}
+
+#side-bar a,
+#interwiki a {
+	color: #b01;
 }
 
 #side-bar .menu-item a,


### PR DESCRIPTION
Remove :visited from the selectors, as #side-bar a has high enough specificity.

Moved to side-bar section.