### PR TITLE
close-menu optimization

### DIFF
--- a/sigma.css
+++ b/sigma.css
@@ -437,7 +437,7 @@ sup {
 	position: absolute;
 	top: 0.5rem;
 	left: 1.5rem;
-	width: 14rem;
+	width: 13.75rem;
 	padding: 0;
 	border: none;
 	display: block;
@@ -621,8 +621,8 @@ sup {
 
 /* CONTENT */
 #main-content {
-	margin: 0 1.5rem 0 18rem;
-	padding: 0.875rem;
+	margin: 0 1.5rem 0 17rem;
+	padding: 0.75rem;
 	position: relative;
 }
 

--- a/sigma.css
+++ b/sigma.css
@@ -559,6 +559,13 @@ sup {
 /* off-canvas */
 .close-menu {
 	display: none;
+	position: fixed;
+	width: 100%;
+	height: 100%;
+	top: 0;
+	left: 0;
+	background: rgba(0, 0, 0, 0.3) 1px 1px repeat;
+	z-index: -1;
 }
 
 /* side bar mobile query on their own */
@@ -603,28 +610,12 @@ sup {
 		transition: left 0.5s ease-in-out 0.1s;
 	}
 
-	#side-bar::after {
-		content: '';
-		position: absolute;
-		top: 0;
-		width: 0;
-		height: 100%;
-		background-color: rgba(0, 0, 0, 0.2);
-	}
-
 	#side-bar:target {
 		left: 0;
 	}
 
 	#side-bar:target .close-menu {
 		display: block;
-		position: fixed;
-		width: 100%;
-		height: 100%;
-		top: 0;
-		left: 0;
-		background: rgba(0, 0, 0, 0.3) 1px 1px repeat;
-		z-index: -1;
 	}
 }
 


### PR DESCRIPTION
Reorganize .close-menu properties to minimize specificity spillover.

Remove useless(?) ::after element on side-bar.

Possibly breaking changes. Don't merge yet until verified.