### PR TITLE
Remove separate node setup

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - '*.css'
+      - '.github/workflows/lint.yaml'
 
 jobs:
   lint:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,11 +14,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - name: Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
Custom node is unnecessary and slows the process down. If this build passes, the PR is good to go.