### PR TITLE
set img block img to 100%

### DIFF
--- a/sigma.css
+++ b/sigma.css
@@ -923,6 +923,7 @@ div.page-rate-widget-box .rate-points {
 
 .scp-image-block img {
 	border: 0;
+	width: 100%;
 }
 
 .scp-image-block .scp-image-caption {


### PR DESCRIPTION
Fix an edge case where an img wont fill image block width if its intrinsic size is less than