### PR TITLE
move overflow-wrap property

### DIFF
--- a/sigma.css
+++ b/sigma.css
@@ -624,6 +624,7 @@ sup {
 	margin: 0 1.5rem 0 17rem;
 	padding: 0.75rem;
 	position: relative;
+	overflow-wrap: break-word;
 }
 
 /* ACTUALLY HIDE HIDDEN TAGS */
@@ -1202,11 +1203,6 @@ table {
 		-webkit-transition: 0.5s ease-in-out 0.1s;
 		-o-transition: 0.5s ease-in-out 0.1s;
 		transition: 0.5s ease-in-out 0.1s;
-	}
-
-	span,
-	a {
-		overflow-wrap: break-word;
 	}
 
 	.page-history tbody tr td:last-child {


### PR DESCRIPTION
`overflow-wrap` should be a more universally applied property - I've moved it to #main-content outside the media query (body was considered, but I wanted to avoid possible layout shift with #header and #side-bar)

Here's a simulated screenshot:
![image](https://github.com/scpwiki/sigma/assets/93550009/bf522803-68ae-4644-a31c-00cbc2aead9d)

With:
![image](https://github.com/scpwiki/sigma/assets/93550009/209bf095-cb62-449b-acae-43a6f610862f)
