### PR TITLE
Fix SVG backgrounds in header on IE by explicitly setting full background-size

### DIFF
--- a/sigma.css
+++ b/sigma.css
@@ -184,6 +184,7 @@ textarea {
 div#container-wrap {
 	background: url('https://scpwiki.github.io/sigma/images/body_bg.svg') top
 		left repeat-x;
+	background-size: 100px 400px;
 }
 
 sup {
@@ -200,7 +201,7 @@ sup {
 	padding-bottom: 22px; /* FOR MENU */
 	background: url('https://scpwiki.github.io/sigma/images/header-logo.svg')
 		10px 40px no-repeat;
-	background-size: 100px;
+	background-size: 100px 100px;
 	background-position: 10px 64%;
 }
 


### PR DESCRIPTION
Before:
![Header background is broken and logo is tiny](https://github.com/scpwiki/sigma/assets/8355305/9c172fa9-e5cc-477c-a0d3-f060fca06b90)
After:
![Page displays mostly correctly](https://github.com/scpwiki/sigma/assets/8355305/5927ce2e-0b0b-4ffb-9e0b-91b38d27e9c0)
