### PR TITLE
Revert "Fix SVG backgrounds in header on IE by explicitly setting full background-size"

### DIFF
--- a/sigma.css
+++ b/sigma.css
@@ -184,7 +184,6 @@ textarea {
 div#container-wrap {
 	background: url('https://scpwiki.github.io/sigma/images/body_bg.svg') top
 		left repeat-x;
-	background-size: 100px 400px;
 }
 
 sup {
@@ -201,7 +200,7 @@ sup {
 	padding-bottom: 22px; /* FOR MENU */
 	background: url('https://scpwiki.github.io/sigma/images/header-logo.svg')
 		10px 40px no-repeat;
-	background-size: 100px 100px;
+	background-size: 100px;
 	background-position: 10px 64%;
 }
 


### PR DESCRIPTION
Reverts scpwiki/sigma#93

According to @SYwaves:
> Do not merge
> We don’t want to add explicit sizing to bg size since it css change some pages on site that rely on intrinsic size of image
> We also dropped ie support already, so it didn’t matter much