### PR TITLE
Use cdn.scpwiki.com links in theme CSS

### DIFF
--- a/sigma.css
+++ b/sigma.css
@@ -22,7 +22,7 @@
 	font-style: normal;
 	font-weight: 100 900;
 	font-display: swap;
-	src: url('https://scpwiki.github.io/sigma/fonts/Inter-roman.var.woff2?v=3.19')
+	src: url('https://cdn.scpwiki.com/theme/en/sigma/fonts/Inter-roman.var.woff2?v=3.19')
 		format('woff2');
 }
 
@@ -31,7 +31,7 @@
 	font-style: italic;
 	font-weight: 100 900;
 	font-display: swap;
-	src: url('https://scpwiki.github.io/sigma/fonts/Inter-italic.var.woff2?v=3.19')
+	src: url('https://cdn.scpwiki.com/theme/en/sigma/fonts/Inter-italic.var.woff2?v=3.19')
 		format('woff2');
 }
 
@@ -40,7 +40,7 @@
 	font-style: normal;
 	font-weight: 700;
 	font-display: swap;
-	src: url('https://scpwiki.github.io/sigma/fonts/Sans-Normalcy.woff2')
+	src: url('https://cdn.scpwiki.com/theme/en/sigma/fonts/Sans-Normalcy.woff2')
 		format('woff2');
 }
 
@@ -49,7 +49,7 @@
 	font-style: normal;
 	font-weight: 400;
 	font-display: swap;
-	src: url('https://scpwiki.github.io/sigma/fonts/NanumGothic-Regular.woff2')
+	src: url('https://cdn.scpwiki.com/theme/en/sigma/fonts/NanumGothic-Regular.woff2')
 		format('woff2');
 }
 
@@ -58,7 +58,7 @@
 	font-style: normal;
 	font-weight: 700;
 	font-display: swap;
-	src: url('https://scpwiki.github.io/sigma/fonts/NanumGothic-Bold.woff2')
+	src: url('https://cdn.scpwiki.com/theme/en/sigma/fonts/NanumGothic-Bold.woff2')
 		format('woff2');
 }
 
@@ -67,7 +67,7 @@
 	font-style: normal;
 	font-weight: 400;
 	font-display: swap;
-	src: url('https://scpwiki.github.io/sigma/fonts/RedactRect.woff2')
+	src: url('https://cdn.scpwiki.com/theme/en/sigma/fonts/RedactRect.woff2')
 		format('woff2');
 	unicode-range: U+2588;
 }
@@ -193,7 +193,7 @@ textarea {
 }
 
 div#container-wrap {
-	background: url('https://scpwiki.github.io/sigma/images/body_bg.svg') top
+	background: url('https://cdn.scpwiki.com/theme/en/sigma/images/body_bg.svg') top
 		left repeat-x;
 }
 
@@ -209,7 +209,7 @@ sup {
 	position: relative;
 	z-index: 10;
 	padding-bottom: 22px; /* FOR MENU */
-	background: url('https://scpwiki.github.io/sigma/images/header-logo.svg')
+	background: url('https://cdn.scpwiki.com/theme/en/sigma/images/header-logo.svg')
 		10px 40px no-repeat;
 	background-size: 100px;
 	background-position: 10px 64%;


### PR DESCRIPTION
We have been using `cdn.scpwiki.com` for a while now, and we want to avoid having to load anything from GitHub Pages (as it being blocked is why we started hosting things on our own site to begin with). This fixes the links used in the CSS source.