### PR TITLE
Invalidate CDN paths properly

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -45,7 +45,7 @@ jobs:
         uses: chetan/invalidate-cloudfront-action@v2
         env:
           DISTRIBUTION: ${{ secrets.CF_DISTRIBUTION }}
-          PATHS: /${{ env.BUCKET_PATH }}
+          PATHS: /${{ env.BUCKET_PATH }}/ /${{ env.BUCKET_PATH }}/*
           AWS_REGION: ${{ vars.AWS_REGION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/build.sh
+++ b/build.sh
@@ -14,3 +14,4 @@ cp -a fonts images dist
 mkdir -p dist/css
 cp sigma.css dist/css
 npm run minify
+[[ -f dist/css/sigma.min.css ]]


### PR DESCRIPTION
This invalidates the `/*` of the path, not just the root. It also adds a check to make sure the minified file was generated.