### PR TITLE
Update deploy workflow to use DigitalOcean Spaces.

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,6 +13,14 @@ jobs:
     name: Deploy CSS
     runs-on: ubuntu-latest
 
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -23,29 +31,33 @@ jobs:
       - name: Build
         run: ./build.sh
 
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist/
+
       - name: Deploy (GitHub Pages)
-        uses: JamesIves/github-pages-deploy-action@4.1.4
-        with:
-          branch: gh-pages
-          folder: dist
+        uses: actions/deploy-pages@v4
+        id: deployment
 
-      - name: Deploy (S3)
-        uses: emmiegit/s3-sync-action@main
-        with:
-          args: --delete
+      - name: Upload to S3
+        run: |
+          export sync_args=( "--delete" "--acl" "public-read" "dist" "s3://${{ vars.AWS_S3_BUCKET }}/${{ env.BUCKET_PATH }}" )
+          # Manually set content-types for anything aws-cli can't guess correctly
+          aws s3 sync ${sync_args[@]} --exclude "*" --include "*.css" --content-type "text/css; charset=utf-8"
+          aws s3 sync ${sync_args[@]} --exclude "*.css"
         env:
-          AWS_S3_BUCKET: ${{ vars.AWS_S3_BUCKET }}
-          AWS_REGION: ${{ vars.AWS_REGION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          SOURCE_DIR: dist
-          DEST_DIR: ${{ env.BUCKET_PATH }}
+          AWS_ENDPOINT_URL: 'https://${{ vars.DIGITALOCEAN_SPACES_REGION }}.digitaloceanspaces.com'
+          AWS_DEFAULT_REGION: 'us-east-1'
 
-      - name: Invalidate CloudFront
-        uses: chetan/invalidate-cloudfront-action@v2
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Invalidate Spaces Cache
+        run: doctl compute cdn flush $DIGITALOCEAN_CDN_ID
         env:
-          DISTRIBUTION: ${{ secrets.CF_DISTRIBUTION }}
-          PATHS: /${{ env.BUCKET_PATH }}/ /${{ env.BUCKET_PATH }}/*
-          AWS_REGION: ${{ vars.AWS_REGION }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          DIGITALOCEAN_CDN_ID: ${{ vars.DIGITALOCEAN_CDN_ID }}


### PR DESCRIPTION
\+ moved certain steps to more "conventional" well-updated actions

The actions/deploy-pages action expects to be run inside the "github-pages" environment, but it should autoconfigure this for you. But this means all variables and secrets should also be set in this environment.

---

Additional setup for DigitalOcean:
- Sign up for an account (and optionally, [create a new team](https://cloud.digitalocean.com/account/team/create))
- Create a [new space](https://cloud.digitalocean.com/spaces/new) and enable the CDN (be warned this starts billing you immediately). The name of the bucket should be stored in `vars.AWS_S3_BUCKET`.
  - The region you create the space in determines the value for `vars.DIGITALOCEAN_SPACES_REGION`.
- Go to [personal access tokens](https://cloud.digitalocean.com/account/api/tokens) and create a new one. You only need to give it update access for "cdn". Set this token as `secrets.DIGITALOCEAN_ACCESS_TOKEN`
- Go to the [spaces keys](https://cloud.digitalocean.com/account/api/spaces) page to generate your `secrets.AWS_ACCESS_KEY_ID` and `secrets.AWS_SECRET_ACCESS_KEY`.
- Install and set up [`doctl`](https://docs.digitalocean.com/reference/doctl/how-to/install/) locally. Run `doctl compute cdn list` and copy the ID for your space and set it as `vars.DIGITALOCEAN_CDN_ID`. Don't think there's a way to get the ID in the console.