### PR TITLE
Adjust Line Height for Footnote Block

### DIFF
--- a/sigma.css
+++ b/sigma.css
@@ -93,7 +93,8 @@ ul {
 }
 
 li,
-p {
+p,
+.footnote-footer {
 	line-height: 1.5;
 }
 

--- a/sigma.css
+++ b/sigma.css
@@ -94,7 +94,8 @@ ul {
 
 li,
 p,
-.footnote-footer {
+.footnote-footer,
+.footnote .f-content {
 	line-height: 1.5;
 }
 

--- a/sigma.css
+++ b/sigma.css
@@ -95,7 +95,9 @@ ul {
 li,
 p,
 .footnote-footer,
-.footnote .f-content {
+.footnote .f-content,
+.bibitems .bibitem,
+.reference .r-content {
 	line-height: 1.5;
 }
 


### PR DESCRIPTION
The block of footnotes at the bottom of the page does not wrap the footnotes into either a `<li>` or `<p>` element, causing it to not inherit the `line-height: 1.5` that paragraphs get by default. This applies that line-height argument to both the footnotes at the bottom of the page and the to the footnote blocks themselves, so it is not compressed.

![image](https://github.com/user-attachments/assets/953f9619-b8e7-474f-b89f-516c1529a1c7)

Footnotes of SCP-3477 at present, in which footnote two gets the line-spacing because of the multiple paragraphs in the footnote, but in which the other footnotes do not have the line spacing.

![image](https://github.com/user-attachments/assets/ed383dc8-1d67-47b9-8c1b-931d397b028c)

Footnotes of SCP-3477 after line-spacing applied to `.footnote-footer`.

![image](https://github.com/user-attachments/assets/d745ec25-069d-4151-975a-0510379d513e)

Current implementation of a footnote hovertip.

![image](https://github.com/user-attachments/assets/e708b139-a8fb-4a92-a599-239df7a1f107)

Footnote after change.

