### PR TITLE
Post Pride Month Logo Reversion

### DIFF
--- a/sigma.css
+++ b/sigma.css
@@ -179,7 +179,7 @@ sup {
 	position: relative;
 	z-index: 10;
 	padding-bottom: 22px; /* FOR MENU */
-	background: url('https://cdn.scpwiki.com/theme/en/sigma/images/header-logo-pride.svg')
+	background: url('https://cdn.scpwiki.com/theme/en/sigma/images/header-logo.svg')
 		10px 40px no-repeat;
 	background-size: 100px;
 	background-position: 10px 64%;


### PR DESCRIPTION
Setting up the pull request to return the site logo to the standard version on July 1st, 2025.